### PR TITLE
enable AssetBundleBuild with variants 

### DIFF
--- a/Assets/Sample/Editor/AssetBundleSampleDataWindow.cs
+++ b/Assets/Sample/Editor/AssetBundleSampleDataWindow.cs
@@ -71,6 +71,7 @@ namespace Sample
 
             if (isSeparate)
             {
+                UTJ.SeparatedAssetBundleBuild.ReservedVariants = testVariants;
                 UTJ.SeparatedAssetBundleBuild.BuildAssetBundles(outputDir, assetBundleBuildOption, targetPlatform);
             }
             else
@@ -152,7 +153,7 @@ namespace Sample
                 {
                     continue;
                 }
-                importer.assetBundleName = "test_with_variant" + i;
+                importer.assetBundleName = "test" + i;
                 importer.assetBundleVariant = variant;
                 importer.textureType = TextureImporterType.GUI;
                 importer.mipmapEnabled = false;

--- a/Assets/SeparatedAssetBundleBuild/Editor/SeparatedAssetBundleBuild.cs
+++ b/Assets/SeparatedAssetBundleBuild/Editor/SeparatedAssetBundleBuild.cs
@@ -2,6 +2,7 @@
 //#define ASSET_BUNDLE_BUILD_TIME_CHECK
 
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using UnityEngine;
 using UnityEditor;
@@ -19,6 +20,7 @@ namespace UTJ
 
         // The number of batchingAssetBundleBuilds.
         private const int BulkConvertNum = 300;
+        public static List<string> ReservedVariants = new List<string>(0);
 
         public static AssetBundleBuildsManifest BuildAssetBundles(string outputDir, BuildAssetBundleOptions buildOption, BuildTarget targetPlatform)
         {
@@ -260,12 +262,33 @@ namespace UTJ
         private static AssetBundleBuild CreateAssetBundleBuildFromAssetBundleName(string assetBundleName)
         {
             AssetBundleBuild build = new AssetBundleBuild();
-            build.assetBundleName = assetBundleName;
+
+            string bundleName;
+            string variant;
+            GetAssetBundleNameAndVariantByReservedVariants(assetBundleName, out bundleName, out variant);
+
+            build.assetBundleName = bundleName;
+            build.assetBundleVariant = variant;
             build.assetNames = AssetDatabase.GetAssetPathsFromAssetBundle(assetBundleName);
             return build;
         }
 
+        private static void GetAssetBundleNameAndVariantByReservedVariants(string originAssetBundleName, out string assetBundleName, out string assetBundleVariant)
+        {
+            assetBundleName = originAssetBundleName;
+            assetBundleVariant = "";
 
+            string extension = Path.GetExtension(assetBundleName);
+            if (!string.IsNullOrEmpty(extension))
+            {
+                extension = extension.Substring(1);
+                if (ReservedVariants.Contains(extension))
+                {
+                    assetBundleName = Path.GetFileNameWithoutExtension(assetBundleName);
+                    assetBundleVariant = extension;
+                }
+            }
+        }
 
     }
 

--- a/Assets/SeparatedAssetBundleBuild/Editor/SeparatedAssetBundleBuild.cs
+++ b/Assets/SeparatedAssetBundleBuild/Editor/SeparatedAssetBundleBuild.cs
@@ -284,7 +284,7 @@ namespace UTJ
                 extension = extension.Substring(1);
                 if (ReservedVariants.Contains(extension))
                 {
-                    assetBundleName = Path.GetFileNameWithoutExtension(assetBundleName);
+                    assetBundleName = Path.Combine(Path.GetDirectoryName(assetBundleName), Path.GetFileNameWithoutExtension(assetBundleName));
                     assetBundleVariant = extension;
                 }
             }


### PR DESCRIPTION
Thanks for solving the problem! I was in trouble.

I want to enable AssetBundleBuild with variants using SeparatedAssetBundleBuild.

## Modification

- add CreateDatasetWithVariants for test.
- modify CreateAssetBundleBuildFromAssetBundleName.
  - make assetBundleVariant using assetBundleName and ReservedVariants.

## Limited

Require Setting UTJ.SeparatedAssetBundleBuild.ReservedVariants by User.
Because there is no method to get assetBundleVariant from assetBundleName.
